### PR TITLE
Update windows-chocolatey.md

### DIFF
--- a/windows-chocolatey.md
+++ b/windows-chocolatey.md
@@ -44,10 +44,10 @@ Agora, teste se a instalação ocorreu corretamente executando o seguinte comand
 choco
 ```
 
-Agora vamos instalar o Node, Python2 e a JDK8 (Java Development Kit 8).
+Agora vamos instalar o Node, Python2, JDK8 (Java Development Kit 8) e o Yarn.
 
 ```sh
-choco install -y nodejs.install python2 jdk8
+choco install -y nodejs.install python2 jdk8 yarn
 ```
 
 *Se você tiver o NodeJS já instalado em sua máquina, certifique-se que sua versão é superior à 7 e caso esteja com o JDK instalado em sua máquina, certifique-se que sua versão seja a 8.*
@@ -56,8 +56,6 @@ Agora com as dependências instaladas, vamos instalar o CLI (Command Line Interf
 
 ```sh
 npm install -g react-native-cli
-
-// Ou yarn global add react-native-cli
 ```
 
 Se tudo ocorreu bem até aqui, você conseguirá executar o seguinte comando:

--- a/windows-chocolatey.md
+++ b/windows-chocolatey.md
@@ -60,8 +60,9 @@ refleshenv
 Agora com as dependências instaladas, vamos instalar o CLI (Command Line Interface) do React Native que nos ajudará na criação e teste de novos projetos. Nesse passo você provavelmente deve reiniciar seu terminal para o comando funcionar.
 
 ```sh
-npm install -g react-native-cli
-```
+yarn add global react-native-cli
+# Ou npm install -g react-native-cli
+``` 
 
 Se tudo ocorreu bem até aqui, você conseguirá executar o seguinte comando:
 

--- a/windows-chocolatey.md
+++ b/windows-chocolatey.md
@@ -52,6 +52,11 @@ choco install -y nodejs.install python2 jdk8 yarn
 
 *Se você tiver o NodeJS já instalado em sua máquina, certifique-se que sua versão é superior à 7 e caso esteja com o JDK instalado em sua máquina, certifique-se que sua versão seja a 8.*
 
+Agora, vamos reiniciar o Terminal (Não se preocupe, ele não vai fechar!)
+```sh
+refleshenv
+```
+
 Agora com as dependências instaladas, vamos instalar o CLI (Command Line Interface) do React Native que nos ajudará na criação e teste de novos projetos. Nesse passo você provavelmente deve reiniciar seu terminal para o comando funcionar.
 
 ```sh


### PR DESCRIPTION
Quando eu instalei o React-Native usando o npm, ele meio que já tentou optar fazer o download pelo Yarn.
O chocolatey "recomenda" instalar o Yarn para fazer com que os downloads sejam mais rápidos.
Eu acho que seria melhor incluir o Yarn, já que não vai custar nada e também vai deixar tudo mais rápido.
![](https://i.ibb.co/drwhGDx/Capturar.png)
Como pode ver, eu nem falei sobre Yarn quando tentei instalar o React-Native, mais mesmo assim, o npm tentou executá-lo.

Desculpe gastar seu tempo com isso ^^\